### PR TITLE
WIP: Add GiteaAuth class and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,29 @@ The parameters are as follows:
 | `context_pr` | `Renderable` The context message to use, when building on a pull request, allowing to identify from which builder this came, defaults to `Interpolate('buildbot/pull_request/%(prop:buildername)s')` |
 | `warningAsSuccess` | Treat warnings as build as success to set in the build status of gitea. If false, warnings will be displayed as warnings. |
 | `verbose` | Perform verbose output |
+
+## Authentication
+
+Gitea supports OAuth2 authentication so it is possible to have buildbot communicate to Gitea to authenticate the user.
+
+`./master.cfg`
+
+```py
+from buildbot_gitea.auth import GiteaAuth
+c['www']['auth'] = GiteaAuth(
+    endpoint="https://your-gitea-host",
+    client_id 'oauth2-client-id',
+    client_secret='oauth2-client-secret')
+```
+
+| Parameter | Value |
+| --- | --- |
+| `endpoint` | The URL to your Gitea app. |
+| `client_id` | The OAuth2 Client ID |
+| `client_secret` | The OAuth2 Client Secret |
+
+Resources:
+
++ [Gitea OAuth2 Provider documentation](https://docs.gitea.io/en-us/oauth2-provider/)
++ [Buildbot OAuth2 documentation](https://docs.buildbot.net/current/developer/cls-auth.html?highlight=oauth2#buildbot.www.oauth2.OAuth2Auth)
++ [Buildbot OAuth2 source](https://github.com/buildbot/buildbot/blob/master/master/buildbot/www/oauth2.py)

--- a/buildbot_gitea/auth.py
+++ b/buildbot_gitea/auth.py
@@ -1,5 +1,5 @@
 from buildbot.www.oauth2 import OAuth2Auth
-import urllib.parse
+from urllib.parse import urljoin
 
 class GiteaAuth(OAuth2Auth):
     name = 'Gitea'
@@ -8,8 +8,8 @@ class GiteaAuth(OAuth2Auth):
     def __init__(self, endpoint, client_id, client_secret):
         super(__class__, self).__init__(client_id, client_secret)
         self.resourceEndpoint = endpoint
-        self.authUri = urllib.parse.urljoin(endpoint, 'login/oauth/authorize')
-        self.tokenUri = urllib.parse.urljoin(endpoint, 'login/oauth/access_token')
+        self.authUri = urljoin(endpoint, 'login/oauth/authorize')
+        self.tokenUri = urljoin(endpoint, 'login/oauth/access_token')
 
     def getUserInfoFromOAuthClient(self, c):
         return self.get(c, '/api/v1/user')

--- a/buildbot_gitea/auth.py
+++ b/buildbot_gitea/auth.py
@@ -1,0 +1,15 @@
+from buildbot.www.oauth2 import OAuth2Auth
+import urllib.parse
+
+class GiteaAuth(OAuth2Auth):
+    name = 'Gitea'
+    faIcon = 'mug-tea'
+
+    def __init__(self, endpoint, client_id, client_secret):
+        super(__class__, self).__init__(client_id, client_secret)
+        self.resourceEndpoint = endpoint
+        self.authUri = urllib.parse.urljoin(endpoint, 'login/oauth/authorize')
+        self.tokenUri = urllib.parse.urljoin(endpoint, 'login/oauth/access_token')
+
+    def getUserInfoFromOAuthClient(self, c):
+        return self.get(c, '/api/v1/user')


### PR DESCRIPTION
## What does it do?

It adds a class to the project that allows users to authenticate over OAuth2.

## How to test

I'm unsure the proper way to test with python but this is how I've configured it.

`./master.cfg`

```py
from buildbot_gitea.auth import GiteaAuth
c['www']['auth'] = GiteaAuth(
    endpoint="https://your-gitea-host",
    client_id 'oauth2-client-id',
    client_secret='oauth2-client-secret')
```

## Demo screens

At buildbot home page

<img width="873" alt="Screen Shot 2019-12-17 at 3 39 33 PM" src="https://user-images.githubusercontent.com/1634015/71040583-272b4180-20e4-11ea-8a1a-aaf6c7bdaa90.png">

When logging in the title comes from this class. With `faIcon` property I don't see it but I copied the other classes, like GitHub, or GitLab, which reference an `faIcon = '?'`. It's from FontAwesome icons. 

<img width="232" alt="Screen Shot 2019-12-17 at 3 40 00 PM" src="https://user-images.githubusercontent.com/1634015/71040610-35795d80-20e4-11ea-829f-dedd1f7507f7.png">

Login at your Gitea

<img width="871" alt="Screen Shot 2019-12-17 at 3 40 49 PM" src="https://user-images.githubusercontent.com/1634015/71040712-796c6280-20e4-11ea-8572-b053010ea874.png">

Authorize buildbot. The title and naming comes from how the user configures it.

<img width="873" alt="Screen Shot 2019-12-17 at 3 43 34 PM" src="https://user-images.githubusercontent.com/1634015/71040725-81c49d80-20e4-11ea-91c5-f6990740f258.png">

The user is logged in

<img width="874" alt="Screen Shot 2019-12-17 at 3 44 17 PM" src="https://user-images.githubusercontent.com/1634015/71040751-91dc7d00-20e4-11ea-9206-565ed3d50d8e.png">

