### PR TITLE
Remove .git from ssh_url_match to get a valid repository name.

### DIFF
--- a/buildbot_gitea/reporter.py
+++ b/buildbot_gitea/reporter.py
@@ -24,7 +24,7 @@ import re
 class GiteaStatusPush(http.HttpStatusPushBase):
     name = "GiteaStatusPush"
     neededDetails = dict(wantProperties=True)
-    ssh_url_match = re.compile(r"(ssh://)?[\w+\-\_]+@[\w\.\-\_]+:?(\d*/)?(?P<owner>[\w_\-\.]+)/(?P<repo_name>[\w_\-\.]+)")
+    ssh_url_match = re.compile(r"(ssh://)?[\w+\-\_]+@[\w\.\-\_]+:?(\d*/)?(?P<owner>[\w_\-\.]+)/(?P<repo_name>[\w_\-\.]+?)(\.git)?")
 
     @defer.inlineCallbacks
     def reconfigService(self, baseURL, token,
@@ -117,14 +117,10 @@ class GiteaStatusPush(http.HttpStatusPushBase):
             if sha is None:
                 # No special revision for this, so ignore it
                 continue
-
-            # Strip tailing .git to exclude it from re.match
-            ssh_url = re.sub('\.git$', '', sourcestamp['repository'])
-
             if 'repository_name' in props:
                 repository_name = props['repository_name']
             else:
-                match = re.match(self.ssh_url_match, ssh_url)
+                match = re.match(self.ssh_url_match, sourcestamp['repository'])
                 if match is not None:
                     repository_name = match.group("repo_name")
                 else:
@@ -132,11 +128,10 @@ class GiteaStatusPush(http.HttpStatusPushBase):
                         "Could not send status, "
                         "build has no repository_name property for Gitea.")
                     continue
-
             if 'owner' in props:
                 repository_owner = props['owner']
             else:
-                match = re.match(self.ssh_url_match, ssh_url)
+                match = re.match(self.ssh_url_match, sourcestamp['repository'])
                 if match is not None:
                     repository_owner = match.group("owner")
                 else:
@@ -144,7 +139,6 @@ class GiteaStatusPush(http.HttpStatusPushBase):
                         "Could not send status, "
                         "build has no owner property for Gitea.")
                     continue
-
             try:
                 target_url = build['url']
                 res = yield self.createStatus(


### PR DESCRIPTION
Current ``ssh_url_match`` would always include trailing '``.git``' from SSH URL in match, which leads to an invalid repository name on REST access. To avoid this, I propose stripping the trailing '``.git``' away from ssh_url with ``re.sub()``.