### PR TITLE
Correct repo_name regex

### DIFF
--- a/buildbot_gitea/reporter.py
+++ b/buildbot_gitea/reporter.py
@@ -24,7 +24,7 @@ import re
 class GiteaStatusPush(http.HttpStatusPushBase):
     name = "GiteaStatusPush"
     neededDetails = dict(wantProperties=True)
-    ssh_url_match = re.compile(r"(ssh://)?[\w+\-\_]+@[\w\.\-\_]+:?(\d*/)?(?P<owner>[\w_\-\.]+)/(?P<repo_name>[\w_\-\.]+?)(\.git)?")
+    ssh_url_match = re.compile(r"(ssh://)?[\w+\-\_]+@[\w\.\-\_]+:?(\d*/)?(?P<owner>[\w_\-\.]+)/(?P<repo_name>[\w_\-\.]+?)(\.git)?$")
 
     @defer.inlineCallbacks
     def reconfigService(self, baseURL, token,


### PR DESCRIPTION
I'm sorry, my repo_name regex correction missed the trailing dollar sign to match the end of line. This PR should fix it finally.