### PR TITLE
Add commits to the changes list in reverse order.

### DIFF
--- a/buildbot_gitea/webhook.py
+++ b/buildbot_gitea/webhook.py
@@ -53,7 +53,7 @@ class GiteaHandler(BaseHookHandler):
             }
             if codebase is not None:
                 change['codebase'] = codebase
-            changes.append(change)
+            changes.insert(0, change)
         return changes
 
     def process_pull_request(self, payload, event_type, codebase):


### PR DESCRIPTION
The gitea webhook list of pushed commits is in order from newest to
oldest.  If commits are appended to the changes array and returned, the
last commit in the array will be the oldest commit in the push.
However, buildbot treats the last change as the *most* recent.  This
means that unless you use 'alwaysUseLatest=True' in your Git step, the
Git step will not check out the newest commit in the push.  If you
happen to be using 'shallow=True', this will actually cause the Git
update step to fail because only the newest commit is available in a
shallow checkout.

This update inserts each commit in the gitea webhook call at the
beginning of the array, which means buildbot sees them in chronological
order.  A Git step with 'shallow=True' will now succeed.