### PR TITLE
Support buildbot 2.9

### DIFF
--- a/buildbot_gitea/reporter.py
+++ b/buildbot_gitea/reporter.py
@@ -23,8 +23,11 @@ import re
 
 class GiteaStatusPush(http.HttpStatusPushBase):
     name = "GiteaStatusPush"
-    neededDetails = dict(wantProperties=True)
     ssh_url_match = re.compile(r"(ssh://)?[\w+\-\_]+@[\w\.\-\_]+:?(\d*/)?(?P<owner>[\w_\-\.]+)/(?P<repo_name>[\w_\-\.]+?)(\.git)?$")
+
+    def checkConfig(self, baseURL, token, startDescription=None, endDescription=None,
+                    context=None, verbose=False, wantProperties=True, **kwargs):
+        super().checkConfig(wantProperties=wantProperties, **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self, baseURL, token,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='buildbot-gitea',
       long_description_content_type="text/markdown",
       packages=['buildbot_gitea'],
       requires=[
-          "buildbot (>=2.0.0)"
+          "buildbot (>=2.9.0)"
       ],
       entry_points={
           "buildbot.webhooks": [


### PR DESCRIPTION
Some changes are necessary to the gitea plugin to work with buildbot 2.9:
- a checkConfig() implementation is necessary to avoid traceback when running `buildbot checkconfig`
- some API alterations are needed to get the plugin to report build status back to gitea correctly

I see there's some test code for this plugin, but I don't know if it works or how to use it...