### PR TITLE
Add list of changed files to "changes".

### DIFF
--- a/buildbot_gitea/webhook.py
+++ b/buildbot_gitea/webhook.py
@@ -33,10 +33,14 @@ class GiteaHandler(BaseHookHandler):
             commits = commits[:1]
 
         for commit in commits:
+            files = []
+            for kind in ('added', 'modified', 'removed'):
+                files.extend(commit.get(kind, []))
             timestamp = dateparse(commit['timestamp'])
             change = {
                 'author': '{} <{}>'.format(commit['author']['name'],
                                            commit['author']['email']),
+                'files': files,
                 'comments': commit['message'],
                 'revision': commit['id'],
                 'when_timestamp': timestamp,


### PR DESCRIPTION
Gitea used to not provide the list of changed files in its webhook, but that was fixed some time ago.  This updates the gitea plugin to provide the list to buildbot like the github plugin does.

I've only verified this against buildbot 2.9, as I can't upgrade to 3.0 yet.  Would it be possible to get this change released as a 1.3.1 version of the gitea plugin, since 1.4.0 requires buildbot >= 3.0?