### PR TITLE
Build status should be on target repo

### DIFF
--- a/buildbot_gitea/reporter.py
+++ b/buildbot_gitea/reporter.py
@@ -158,14 +158,16 @@ class GiteaStatusPush(http.ReporterBase):
 
         for sourcestamp in sourcestamps:
             sha = sourcestamp['revision']
+            if 'head_sha' in props:
+                sha = props['head_sha']
             repository_owner = None
             if sha is None:
                 # No special revision for this, so ignore it
                 continue
             # If this is a pull request, send the status to the head repository
             if 'pr_id' in props:
-                repository_name = props['head_reponame']
-                repository_owner = props['head_owner']
+                repository_name = props['repository_name']
+                repository_owner = props['owner']
             elif 'repository_name' in props:
                 repository_name = props['repository_name']
             else:


### PR DESCRIPTION
Having played with the 1.6.0 version a bit, I found that I had to change
the repository_owner and repository_name name from head_reponame and
head_owner to repository_name and owner, respectively.

Originally, I got the status reported on the source repository, on the
previous commit in my repo. What I wanted was to have the status
reported on the PR on the target repo.

I admit I haven't done a huge amount of reading of the code, but what it
looks like to me is that head_reponame and head_owner are refering to
the source repo, so I changed those to repository_name and owner, which
- at least for my setup - point to the target repository of the PR.

Furthermore, in the 1.6.0 code, sha was set to sourcestamp['revision'],
which for me points to the previous commit in the repo, meaning the
status would be reported on the wrong commit in case of a PR.

So for PRs (which I think all have 'head_sha' in props), I am setting
sha to props['head_sha'].

The result of this change for me is that the status of PR testing is
reported on the target repo on the correct commit (so showing up as
green checkmarks / yellow balls / red crosses on the PR).

For normal commits on this same repo, this also works.