### PR TITLE
Add parameter to ignore mergeable check

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ Note that the handlers need to be named according to the scheme:
 
 The change hook is set as part of the `www` section in the `change_hook_dialects` named `gitea`.
 
-| Parameter | Description |
-| --- | --- |
-| `secret` | The secret, which needs to be set in gitea |
-| `onlyIncludePushCommit` | A push may have more than one commit associated with it. If this is true, only the newest (latest) commit of all received will be added as a change to buildbot. If this is set to false, all commits will inside the push will be added. |
-| `class` | Set this if you want to use your own handler class (see above for details) |
+| Parameter                  | Description                                                                                                                                                                                                                               |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `secret`                   | The secret, which needs to be set in gitea                                                                                                                                                                                                |
+| `onlyIncludePushCommit`    | A push may have more than one commit associated with it. If this is true, only the newest (latest) commit of all received will be added as a change to buildbot. If this is set to false, all commits will inside the push will be added. |
+| `onlyMergeablePullRequest` | Ignore pull request if not mergeable. If this is true, only mergeable pull requests will be processed.                                                                                                                                    |
+| `class`                    | Set this if you want to use your own handler class (see above for details)                                                                                                                                                                |
 
 In gitea in your project or organization and add a new webhook of type gitea.
 Set the parameters as follows:

--- a/buildbot_gitea/webhook.py
+++ b/buildbot_gitea/webhook.py
@@ -75,7 +75,7 @@ class GiteaHandler(BaseHookHandler):
             log.msg("Gitea Pull Request event '{}' ignored".format(action))
             return []
         pull_request = payload['pull_request']
-        if not pull_request['mergeable']:
+        if not pull_request['mergeable'] and self.options.get('ignoreMergeablePullRequest', True):
             log.msg("Gitea Pull Request ignored because it is not mergeable.")
             return []
         if pull_request['merged']:

--- a/buildbot_gitea/webhook.py
+++ b/buildbot_gitea/webhook.py
@@ -75,7 +75,7 @@ class GiteaHandler(BaseHookHandler):
             log.msg("Gitea Pull Request event '{}' ignored".format(action))
             return []
         pull_request = payload['pull_request']
-        if not pull_request['mergeable'] and self.options.get('ignoreMergeablePullRequest', True):
+        if not pull_request['mergeable'] and self.options.get('onlyMergeablePullRequest', True):
             log.msg("Gitea Pull Request ignored because it is not mergeable.")
             return []
         if pull_request['merged']:


### PR DESCRIPTION
As discussed in #31 this PR will add a parameter to skip `mergeable` checks.

Sorry, it took quite some time but i wanted to test this properly. Had to set up another Buildbot environment for it. It's just a single line but i still didn't want to break my main one.