### PR TITLE
Fix syntax in step_source.py

### DIFF
--- a/buildbot_gitea/step_source.py
+++ b/buildbot_gitea/step_source.py
@@ -20,7 +20,7 @@ class Gitea(Git):
         if self.build.hasProperty("pr_id"):
             remote = yield self._dovccmd(
                 ['config', 'remote.pr_source.url'], collectStdout=True, abandonOnFailure=False)
-            if remote is None or remote.strip() is '':
+            if remote is None or remote.strip() == '':
                 yield self._dovccmd(
                     ['remote', 'add', 'pr_source',
                      self.build.getProperty("head_git_ssh_url", None)])


### PR DESCRIPTION
Installed the most recent update after the PR and got a warning:

```
/usr/lib/python3.11/site-packages/buildbot_gitea/step_source.py:23: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

This PR fixes the warning.