### PR TITLE
WIP: fix no change on pushing tags

### DIFF
--- a/buildbot_gitea/webhook.py
+++ b/buildbot_gitea/webhook.py
@@ -35,6 +35,11 @@ class GiteaHandler(BaseHookHandler):
         project = repository['full_name']
 
         commits = payload['commits']
+
+        # In case it is a tag it will only contain a head_commit
+        if len(commits) == 0 and re.match(r"^refs/tags/.*$", refname):
+            commits = [payload['head_commit']]
+
         if isinstance(self.options, dict) and self.options.get('onlyIncludePushCommit', False):
             commits = commits[:1]
 


### PR DESCRIPTION
fixes: https://github.com/lab132/buildbot-gitea/issues/36

I tried it on our staging setup, it works as expected now.

I tried to run the tests in the repository, most of them (8) however have failed. I installed both the `requirements.txt` and the `testrequirements.txt`.

I ran the test as following: `python3 setup.py test`

The errors are related to imports:

```
ImportError: cannot import name 'TestReactorMixin' from 'buildbot.test.util.misc'
ImportError: Failed to import test module: buildbot_gitea.test.test_auth
ImportError: Failed to import test module: buildbot_gitea.test.test_reporter
ImportError: Failed to import test module: buildbot_gitea.test.test_step_source
ImportError: Failed to import test module: buildbot_gitea.test.test_webhook
ImportError: Failed to import test module: test_auth
ImportError: Failed to import test module: test_reporter
ImportError: Failed to import test module: test_step_source
ImportError: Failed to import test module: test_webhook
ModuleNotFoundError: No module named 'buildbot.test.fake.remotecommand'
ModuleNotFoundError: No module named 'mock'
```

Am I missing something?