### PR TITLE
WIP: Update tests for new API

### DIFF
--- a/buildbot_gitea/test/test_auth.py
+++ b/buildbot_gitea/test/test_auth.py
@@ -2,7 +2,7 @@ import json
 import mock
 from buildbot.process.properties import Secret
 from buildbot.test.util.config import ConfigErrorsMixin
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.util import www
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -30,7 +30,7 @@ class FakeResponse:
 class TestGiteaAuth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
                     unittest.TestCase):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")
 

--- a/buildbot_gitea/test/test_reporter.py
+++ b/buildbot_gitea/test/test_reporter.py
@@ -17,7 +17,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.util import logging
 from buildbot.test.util.reporter import ReporterTestMixin
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 
 
 
@@ -29,15 +29,13 @@ class TestGiteaStatusPush(
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
 
         self.setup_reporter_test()
 
-    # repository must be in the form http://gitea/<owner>/<project>
+        # repository must be in the form http://gitea/<owner>/<project>
         self.reporter_test_repo = u'http://gitea/buildbot/buildbot'
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(testcase=self,
                                              wantData=True, wantDb=True, wantMq=True)
 
@@ -59,7 +57,7 @@ class TestGiteaStatusPush(
 
     @defer.inlineCallbacks
     def setupBuildResults(self, buildResults):
-        self.insertTestData([buildResults], buildResults)
+        self.insert_test_data([buildResults], buildResults)
         build = yield self.master.data.get(("builds", 20))
         defer.returnValue(build)
 
@@ -72,20 +70,23 @@ class TestGiteaStatusPush(
             'post',
             '/api/v1/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
             json={'state': 'pending',
-                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'description': 'Build started.', 'context': 'buildbot/Builder0'})
+                  'description': 'Build started.',
+                  'target_url': 'http://localhost:8080/#/builders/79/builds/0',
+                  'context': 'buildbot/Builder0'})
         self._http.expect(
             'post',
             '/api/v1/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
             json={'state': 'success',
-                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'description': 'Build done.', 'context': 'buildbot/Builder0'})
+                  'description': 'Build done.',
+                  'target_url': 'http://localhost:8080/#/builders/79/builds/0',
+                  'context': 'buildbot/Builder0'})
         self._http.expect(
             'post',
             '/api/v1/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
             json={'state': 'failure',
-                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'description': 'Build done.', 'context': 'buildbot/Builder0'})
+                  'description': 'Build done.',
+                  'target_url': 'http://localhost:8080/#/builders/79/builds/0',
+                  'context': 'buildbot/Builder0'})
 
         build['complete'] = False
         self.sp._got_event(('builds', 20, 'new'), build)
@@ -107,12 +108,13 @@ class TestGiteaStatusPush(
             'post',
             '/api/v1/repos/foo/bar/statuses/52c7864e56d1425f4c0a76c1e692942047bdd849',
             json={'state': 'success',
-                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'description': 'Build done.', 'context': 'buildbot/pull_request/Builder0'})
+                  'description': 'Build done.',
+                  'target_url': 'http://localhost:8080/#/builders/79/builds/0',
+                  'context': 'buildbot/pull_request/Builder0'})
 
         build['complete'] = True
         self.sp._got_event(('builds', 20, 'finished'), build)
-        
+
     @defer.inlineCallbacks
     def test_sshurl(self):
         self.setupProps()
@@ -123,8 +125,9 @@ class TestGiteaStatusPush(
             'post',
             '/api/v1/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
             json={'state': 'pending',
-                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'description': 'Build started.', 'context': 'buildbot/Builder0'})
+                  'description': 'Build started.',
+                  'target_url': 'http://localhost:8080/#/builders/79/builds/0',
+                  'context': 'buildbot/Builder0'})
         build['complete'] = False
         self.sp._got_event(('builds', 20, 'new'), build)
 
@@ -137,8 +140,9 @@ class TestGiteaStatusPush(
             'post',
             '/api/v1/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
             json={'state': 'pending',
-                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'description': 'Build started.', 'context': 'buildbot/Builder0'})
+                  'description': 'Build started.',
+                  'target_url': 'http://localhost:8080/#/builders/79/builds/0',
+                  'context': 'buildbot/Builder0'})
         build['complete'] = False
         self.sp._got_event(('builds', 20, 'new'), build)
 
@@ -178,8 +182,9 @@ class TestGiteaStatusPush(
             'post',
             '/api/v1/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
             json={'state': 'pending',
-                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'description': 'Build started.', 'context': 'buildbot/Builder0'},
+                  'description': 'Build started.',
+                  'target_url': 'http://localhost:8080/#/builders/79/builds/0',
+                  'context': 'buildbot/Builder0'},
             content_json={
                 "message": "sha1 not found: d34db33fd43db33f",
                 "url": "https://godoc.org/github.com/go-gitea/go-sdk/gitea"
@@ -204,7 +209,7 @@ class TestGiteaStatusPush(
             json={
                 'state': 'pending',
                 'description': 'Build started.',
-                'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                'target_url': 'http://localhost:8080/#/builders/79/builds/0',
                 'context': 'buildbot/Builder0'
             },
             content_json={"message": "Not found"},

--- a/buildbot_gitea/test/test_webhook.py
+++ b/buildbot_gitea/test/test_webhook.py
@@ -1,7 +1,7 @@
 import buildbot.www.change_hook as change_hook
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
-from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.reactor import TestReactorMixin
 from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.process.properties import Secret
@@ -1279,7 +1279,7 @@ giteaJsonPushEmptyFiles = rb"""
 
 class TestChangeHookGiteaPush(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitea': {}},
             master=fakeMasterForHooks(self))
@@ -1481,7 +1481,7 @@ class TestChangeHookGiteaPush(unittest.TestCase, TestReactorMixin):
 
 class TestChangeHookGiteaPushOnlySingle(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitea': {"onlyIncludePushCommit": True}},
             master=fakeMasterForHooks(self))
@@ -1518,7 +1518,7 @@ class TestChangeHookGiteaPushOnlySingle(unittest.TestCase, TestReactorMixin):
 
 class TestChangeHookGiteaSecretPhrase(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitea': {"secret": "test"}},
             master=fakeMasterForHooks(self))
@@ -1546,7 +1546,7 @@ class TestChangeHookGiteaSecretPhrase(unittest.TestCase, TestReactorMixin):
 
 class TestChangeHookGiteaSecretPhraseProvider(unittest.TestCase, TestReactorMixin):
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.master = fakeMasterForHooks(self)
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitea': {"secret": Secret("token")}},
@@ -1590,7 +1590,7 @@ class TestChangeHookGiteaClass(unittest.TestCase, TestReactorMixin):
             return [{'category': self.fakeCategory}]
 
     def setUp(self):
-        self.setUpTestReactor()
+        self.setup_test_reactor()
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitea': {'class': self.GiteaTestHandler}},
             master=fakeMasterForHooks(self))

--- a/buildbot_gitea/webhook.py
+++ b/buildbot_gitea/webhook.py
@@ -35,6 +35,11 @@ class GiteaHandler(BaseHookHandler):
         project = repository['full_name']
 
         commits = payload['commits']
+
+        # In case it is a tag it will only contain a head_commit
+        if len(commits) == 0 and re.match(r"^refs/tags/.*$", refname):
+            commits = [payload['head_commit']]
+
         if isinstance(self.options, dict) and self.options.get('onlyIncludePushCommit', False):
             commits = commits[:1]
 

--- a/testrequirements.txt
+++ b/testrequirements.txt
@@ -1,1 +1,4 @@
 buildbot[test]
+mock
+requests
+buildbot-www


### PR DESCRIPTION
I found a little while to try and update the test to get them to run.

I managed to get all of the running except for `test_step_source`. I was unable to get that one to work as it failed on non matching expected commands. If you might find a while to look into it I'm certain you'll easily find a fix.

This should be merged after https://github.com/lab132/buildbot-gitea/pull/37. I might even add a test there for the fixed bug.

I also made a branch with rewrite of the slowly deprecating `setup.py` to `pyproject.toml` to comply with newer PEPs: https://github.com/tadeas-vintrlik/buildbot-gitea/tree/feature/pyproject.

It could either be a part of this PR or a separate one, whichever you prefer.