### PR TITLE
reporter: create status in the base repository of a pull requests

### DIFF
--- a/buildbot_gitea/reporter.py
+++ b/buildbot_gitea/reporter.py
@@ -164,12 +164,10 @@ class GiteaStatusPush(http.ReporterBase):
             if sha is None:
                 # No special revision for this, so ignore it
                 continue
-            # If this is a pull request, send the status to the head repository
             if 'pr_id' in props:
-                repository_name = props['head_reponame']
-                repository_owner = props['head_owner']
                 sha = props['head_sha']
-            elif 'repository_name' in props:
+
+            if 'repository_name' in props:
                 repository_name = props['repository_name']
             else:
                 match = re.match(self.ssh_url_match, sourcestamp['repository'])


### PR DESCRIPTION
Buildbot might not have access to the build status of the fork and for pull request we want the information in the pull request window rather than the commit on the fork.