### PR TITLE
Fix login icon

### DIFF
--- a/buildbot_gitea/auth.py
+++ b/buildbot_gitea/auth.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 
 class GiteaAuth(OAuth2Auth):
     name = 'Gitea'
-    faIcon = 'fa-coffee'
+    faIcon = 'si-gitea'
 
     AUTH_URL = 'login/oauth/authorize'
     TOKEN_URL = 'login/oauth/access_token'


### PR DESCRIPTION
In #41, I once fixed the icon, but in the meantime not only did Font Awesome put the icon in question behind a paywall, but Buildbot also reworked the processing of icon strings. Now, the icons are pre-imported from [React icons](https://react-icons.github.io/react-icons/). The Gitea icon is provided by Simple Icons there. Hence, I opended a [PR](https://github.com/buildbot/buildbot/pull/8620/commits/12a059fe44e62abcdb5a6fbac76961e85bcbd4c0) trying to support this plugin.